### PR TITLE
Added support for CentOS 6.x package names

### DIFF
--- a/recipes/module_gd.rb
+++ b/recipes/module_gd.rb
@@ -20,7 +20,13 @@
 #
 
 pkg = value_for_platform(
-    [ "centos", "redhat", "fedora" ] => {"default" => "php53-gd"}, 
+    [ "centos", "redhat" ] => {
+      [ "6.0", "6.1", "6.2" ] => "php-gd",
+      "default" => "php53-gd"
+    }, 
+    "fedora" => {
+      "default" => "php53-gd"
+    },
     "default" => "php5-gd"
   )
 

--- a/recipes/module_ldap.rb
+++ b/recipes/module_ldap.rb
@@ -20,7 +20,13 @@
 #
 
 pkg = value_for_platform(
-    [ "centos", "redhat", "fedora" ] => {"default" => "php53-ldap"}, 
+    [ "centos", "redhat" ] => {
+      [ "6.0", "6.1", "6.2" ] => "php-ldap",
+      "default" => "php53-ldap"
+    }, 
+    "fedora" => {
+      "default" => "php53-ldap"
+    },
     "default" => "php5-ldap"
   )
 

--- a/recipes/module_mysql.rb
+++ b/recipes/module_mysql.rb
@@ -20,7 +20,13 @@
 #
 
 pkg = value_for_platform(
-    [ "centos", "redhat", "fedora" ] => {"default" => "php53-mysql"}, 
+    [ "centos", "redhat" ] => {
+      [ "6.0", "6.1", "6.2" ] => "php-mysql",
+      "default" => "php53-mysql"
+    }, 
+    "fedora" => {
+      "default" => "php53-mysql"
+    },
     "default" => "php5-mysql"
   )
 

--- a/recipes/module_pgsql.rb
+++ b/recipes/module_pgsql.rb
@@ -20,7 +20,13 @@
 #
 
 pkg = value_for_platform(
-    [ "centos", "redhat", "fedora" ] => {"default" => "php53-pgsql"}, 
+    [ "centos", "redhat" ] => {
+      [ "6.0", "6.1", "6.2" ] => "php-pgsql",
+      "default" => "php53-pgsql"
+    }, 
+    "fedora" => {
+      "default" => "php53-pgsql"
+    },
     "default" => "php5-pgsql"
   )
 

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -19,7 +19,11 @@
 #
 
 pkgs = value_for_platform(
-  [ "centos", "redhat", "fedora" ] => {
+  [ "centos", "redhat"] => {
+    [ "6.0", "6.1", "6.2" ] => %w{ php php-devel php-cli php-pear },
+    "default" => %w{ php53 php53-devel php53-cli php-pear }
+  },
+  [ "fedora" ] => {
     "default" => %w{ php53 php53-devel php53-cli php-pear }
   },
   [ "debian", "ubuntu" ] => {


### PR DESCRIPTION
In CentOS and RHEL 6.x, php53\* packages have been renamed to php\* to reflect the fact that versions of php prior to 5.3 are not supported and 5.3 is the official version of Cent and RH 6.

I have changed the package references to include this update so that the php cookbook works on CentOS and RHEL 6.x
