### PR TITLE
Removed global dependency for mysql

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,6 @@ version           "1.0.2"
 
 depends "build-essential"
 depends "xml"
-depends "mysql"
 
 %w{ debian ubuntu centos redhat fedora }.each do |os|
   supports os


### PR DESCRIPTION
PHP should not depend on MySQL.  Many projects are using other databases. 
