### PR TITLE
Additional rescue - Chef 0.10.10

### DIFF
--- a/providers/pear_channel.rb
+++ b/providers/pear_channel.rb
@@ -85,7 +85,6 @@ def exists?
     true
   rescue Chef::Exceptions::ShellCommandFailed
   rescue Mixlib::ShellOut::ShellCommandFailed
-  rescue NameError
     false
   end
 end


### PR DESCRIPTION
Eg.
php_pear_channel "pear.symfony-project.com" do
    action :discover
end

...fails because in the exists, "channel-info" is used and a Mixlib::ShellOut::ShellCommandFailed is thrown in Chef 0.10.10.

rescue Chef::Exceptions::ShellCommandFailed is required by 0.10.8
rescue Mixlib::ShellOut::ShellCommandFailed is new in 0.10.10
rescue NameError handles the missing Mixlib::ShellOut::ShellCommandFailed for 0.10.8

Let me know if you need any other information - thanks in advance!

Kind regards,
David Joos
