### PR TITLE
fix for 10.12 

### DIFF
--- a/providers/pear_channel.rb
+++ b/providers/pear_channel.rb
@@ -83,7 +83,7 @@ def exists?
   begin
     shell_out!("pear channel-info #{@current_resource.channel_name}")
     true
-  rescue Chef::Exceptions::ShellCommandFailed
+  rescue Chef::Exceptions::ShellCommandFailed, Mixlib::ShellOut::ShellCommandFailed
     false
   end
 end


### PR DESCRIPTION
In 10.12 shell_out raises Mixlib::ShellOut::ShellCommandFailed

There's a similar issue that's already been fixed in the python cookbook
