### PR TITLE
[COOK-1803] php_pear: Search for exact match on the services, raise exception if not found

### DIFF
--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -248,12 +248,12 @@ def pecl?
   @pecl ||= begin
     # search as a pear first since most 3rd party channels will report pears as pecls!
     search_cmd = "pear -d preferred_state=#{can_haz(@new_resource, "preferred_state")} search#{expand_channel(can_haz(@new_resource, "channel"))} #{@new_resource.package_name}"
-    if shell_out(search_cmd).stdout.find { |line| line =~ /^#{@new_resource.package_name}/ }
+    if shell_out(search_cmd).stdout.find { |line| line =~ /^#{@new_resource.package_name}\s\d+\.\d+\.\d+/ }
       false
     else
       # fall back and search as a pecl
       search_cmd = "pecl -d preferred_state=#{can_haz(@new_resource, "preferred_state")} search#{expand_channel(can_haz(@new_resource, "channel"))} #{@new_resource.package_name}"
-      if shell_out(search_cmd).stdout.find { |line| line =~ /^#{@new_resource.package_name}/ }
+      if shell_out(search_cmd).stdout.find { |line| line =~ /^#{@new_resource.package_name}\s\d+\.\d+\.\d+/ }
         true
       else
         raise "Package #{@new_resource.package_name} not found in either PEAR or PECL."


### PR DESCRIPTION
I need to install "gearman" from PECL.

The way that the cookbook currently works, it first searches PEAR, which returns this:

vagrant@gearman:~$ pear search gearman
Retrieving data...0%
# Matched packages, channel pear.php.net:

Package     Stable/(Latest) Local
Net_Gearman 0.2.3 (alpha)         A PHP interface to Gearman

Now, since the "pecl?" method returns false when the output matches /.?Matched packages/i [ http://bit.ly/UonVa0 ], then the provider assumes that "gearman" was found in PEAR (which it wasn't), and goes on to try to install from there.

It then fails to install (since "gearman" is not a package that exists in PEAR), but the chef run goes on as though everything was fine.

Now, I'm pointing out two different problems here, and my ideal solution would be to raise an exception if an exact match was not found in either service: https://github.com/cassianoleal/php/commit/052ad923412c020eeabe164782827b31fb40cffc

I'm not sure if that won't break some other desired behaviour (such as not raising an exception if PEAR or PECL is offline, for example). If you want, go ahead and merge this pull request. :)
