### PR TITLE
php_pear command should run as a configurable user/group

### DIFF
--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -250,12 +250,12 @@ def pecl?
   @pecl ||= begin
     # search as a pear first since most 3rd party channels will report pears as pecls!
     search_cmd = "pear -d preferred_state=#{can_haz(@new_resource, "preferred_state")} search#{expand_channel(can_haz(@new_resource, "channel"))} #{@new_resource.package_name}"
-    if shell_out(search_cmd).stdout.split("\n").find { |line| line =~ /^#{@new_resource.package_name}\s+\d+\.\d+\.\d+/ }
+    if shell_out(search_cmd, :user => 'root', :group => 'root').stdout.split("\n").find { |line| line =~ /^#{@new_resource.package_name}\s+\d+\.\d+\.\d+/ }
       false
     else
       # fall back and search as a pecl
       search_cmd = "pecl -d preferred_state=#{can_haz(@new_resource, "preferred_state")} search#{expand_channel(can_haz(@new_resource, "channel"))} #{@new_resource.package_name}"
-      if shell_out(search_cmd).stdout.split("\n").find { |line| line =~ /^#{@new_resource.package_name}\s+\d+\.\d+\.\d+/ }
+      if shell_out(search_cmd, :user => 'root', :group => 'root').stdout.split("\n").find { |line| line =~ /^#{@new_resource.package_name}\s+\d+\.\d+\.\d+/ }
         true
       else
         raise "Package #{@new_resource.package_name} not found in either PEAR or PECL."


### PR DESCRIPTION
I had a permission issue with the php_pear command not running as root on Ubuntu (Vagrant precise64). This is fixed by running the shell_out command as a root user/group. Is it possible to make this configurable in this cookbook?
