### PR TITLE
[COOK-3402] When the ext_dir setting is present, configure php properly for the source recipe

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -47,18 +47,23 @@ remote_file "#{Chef::Config[:file_cache_path]}/php-#{version}.tar.gz" do
   not_if "which php"
 end
 
-directory node['php']['ext_dir']  do
-  owner "root"
-  group "root"
-  mode "0755"
-  recursive true
-end if node['php']['ext_dir']
+if node['php']['ext_dir']
+  directory node['php']['ext_dir'] do
+    owner "root"
+    group "root"
+    mode "0755"
+    recursive true
+  end
+  ext_dir_prefix = "EXTENSION_DIR=#{node['php']['ext_dir']}"
+else
+  ext_dir_prefix = ""
+end
 
 bash "build php" do
   cwd Chef::Config[:file_cache_path]
   code <<-EOF
   tar -zxvf php-#{version}.tar.gz
-  (cd php-#{version} && #{(node['php']['ext_dir']) ? "EXTENSION_DIR=#{node['php']['ext_dir']}" : ''} ./configure #{configure_options})
+  (cd php-#{version} && #{ext_dir_prefix} ./configure #{configure_options})
   (cd php-#{version} && make && make install)
   EOF
   not_if "which php"


### PR DESCRIPTION
Under CentOS, when php is built from source the extension dir is not set. This results in something like

```
$ php-config --extension-dir
/usr/local/lib/php/extensions/no-debug-non-zts-20100525
```

which means that pecl extensions installed with the `php_pear` resource will not work (ie, the extension.so file will not be copied to the proper directory)
