### PR TITLE
[COOK-2844] php.ini configuration overwrite

### DIFF
--- a/templates/centos/php.ini.erb
+++ b/templates/centos/php.ini.erb
@@ -1221,5 +1221,5 @@ soap.wsdl_cache_ttl=86400
 ; End:
 
 <% @directives.each do |directive, value| -%>
-<%= "#{directive}=\"#{value}\"" %>
+<%= "#{directive} = #{value}" %>
 <% end -%>

--- a/templates/debian/php.ini.erb
+++ b/templates/debian/php.ini.erb
@@ -1853,5 +1853,5 @@ ldap.max_links = -1
 ; End:
 
 <% @directives.each do |directive, value| -%>
-<%= "#{directive}=\"#{value}\"" %>
+<%= "#{directive} = #{value}" %>
 <% end -%>

--- a/templates/default/extension.ini.erb
+++ b/templates/default/extension.ini.erb
@@ -3,5 +3,5 @@
 <%= 'zend_' if zend %>extension=<%= filepath %>
 <% end -%>
 <% @directives.each do |k,v| -%>
-<%= "#{@name}.#{k}=\"#{v}\"" %>
+<%= "#{@name}.#{k}= #{v}" %>
 <% end -%>

--- a/templates/default/php.ini.erb
+++ b/templates/default/php.ini.erb
@@ -1896,5 +1896,5 @@ ldap.max_links = -1
 ; End:
 
 <% @directives.each do |directive, value| -%>
-<%= "#{directive}=\"#{value}\"" %>
+<%= "#{directive} = #{value}" %>
 <% end -%>

--- a/templates/redhat/php.ini.erb
+++ b/templates/redhat/php.ini.erb
@@ -1221,5 +1221,5 @@ soap.wsdl_cache_ttl=86400
 ; End:
 
 <% @directives.each do |directive, value| -%>
-<%= "#{directive}=\"#{value}\"" %>
+<%= "#{directive} = #{value}" %>
 <% end -%>

--- a/templates/ubuntu/php.ini.erb
+++ b/templates/ubuntu/php.ini.erb
@@ -1853,5 +1853,5 @@ ldap.max_links = -1
 ; End:
 
 <% @directives.each do |directive, value| -%>
-<%= "#{directive}=\"#{value}\"" %>
+<%= "#{directive} = #{value}" %>
 <% end -%>


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2844

Hi to all,
When I try to overwrite configuration in php.ini with this cookbook all parameters are wrapped with quotes. A lot of configurations doesn't work.

In your opinion isn't better if you place directives without quotes and is the developer responsibility to add quotes in dedicated options?

```
node["php"]["directives"]["short_tags"] = "On"
```

should be in php.ini

```
short_tags = On
```

In case we need quotes

```
node["php"]["directives"]["particular_string"] = "\"On\""
```

in php.ini

```
particular_string = "On"
```
