### PR TITLE
[COOK-2778] RHEL < 6.0, use 'php53-' prefixed pkgs

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,11 @@
 lib_dir = kernel['machine'] =~ /x86_64/ ? 'lib64' : 'lib'
 
 default['php']['install_method'] = 'package'
-default['php']['directives'] = {}
+default['php']['directives']     = {}
+default['php']['gd_package']     = 'php5-gd'
+default['php']['ldap_package']   = 'php5-ldap'
+default['php']['mysql_package']  = 'php5-mysql'
+default['php']['pgsql_package']  = 'php5-pgsql'
 
 case node["platform_family"]
 when "rhel", "fedora"
@@ -32,8 +36,16 @@ when "rhel", "fedora"
   default['php']['ext_dir']       = "/usr/#{lib_dir}/php/modules"
   if node['platform_version'].to_f < 6 then
     default['php']['packages'] = ['php53', 'php53-devel', 'php53-cli', 'php-pear']
+    default['php']['gd_package'] = 'php53-gd'
+    default['php']['ldap_package'] = 'php53-ldap'
+    default['php']['mysql_package'] = 'php53-mysql'
+    default['php']['pgsql_package']  = 'php53-pgsql'
   else
     default['php']['packages'] = ['php', 'php-devel', 'php-cli', 'php-pear']
+    default['php']['gd_package'] = 'php-gd'
+    default['php']['ldap_package'] = 'php-ldap'
+    default['php']['mysql_package'] = 'php-mysql'
+    default['php']['pgsql_package']  = 'php-pgsql'
   end
 when "debian"
   default['php']['conf_dir']      = '/etc/php5/cli'

--- a/recipes/module_gd.rb
+++ b/recipes/module_gd.rb
@@ -19,14 +19,6 @@
 # limitations under the License.
 #
 
-pkg = value_for_platform(
-  %w(centos redhat scientific fedora amazon) => {
-    %w(5.0 5.1 5.2 5.3 5.4 5.5 5.6 5.7 5.8) => "php53-gd",
-    "default" => "php-gd"
-  },
-  "default" => "php5-gd"
-)
-
-package pkg do
+package node['php']['gd_package'] do
   action :install
 end

--- a/recipes/module_ldap.rb
+++ b/recipes/module_ldap.rb
@@ -19,14 +19,6 @@
 # limitations under the License.
 #
 
-pkg = value_for_platform(
-  %w(centos redhat scientific fedora amazon) => {
-    %w(5.0 5.1 5.2 5.3 5.4 5.5 5.6 5.7 5.8) => "php53-ldap",
-    "default" => "php-ldap"
-  },
-  "default" => "php5-ldap"
-)
-
-package pkg do
+package node['php']['ldap_package'] do
   action :install
 end

--- a/recipes/module_mysql.rb
+++ b/recipes/module_mysql.rb
@@ -19,14 +19,6 @@
 # limitations under the License.
 #
 
-pkg = value_for_platform(
-  %w(centos redhat scientific fedora amazon) => {
-    %w(5.0 5.1 5.2 5.3 5.4 5.5 5.6 5.7 5.8) => "php53-mysql",
-    "default" => "php-mysql"
-  },
-  "default" => "php5-mysql"
-)
-
-package pkg do
+package node['php']['mysql_package'] do
   action :install
 end

--- a/recipes/module_pgsql.rb
+++ b/recipes/module_pgsql.rb
@@ -19,14 +19,6 @@
 # limitations under the License.
 #
 
-pkg = value_for_platform(
-  %w(centos redhat scientific fedora amazon) => {
-    %w(5.0 5.1 5.2 5.3 5.4 5.5 5.6 5.7 5.8) => "php53-pgsql",
-    "default" => "php-pgsql"
-  },
-  "default" => "php5-pgsql"
-)
-
-package pkg do
+package node['php']['pgsql_package'] do
   action :install
 end


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2778

On RHEL, for PHP and ldap packages, use "php53-*" versions
