### PR TITLE
[COOK-2926] fix pear package detection when installing specific version

### DIFF
--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -250,12 +250,12 @@ def pecl?
   @pecl ||= begin
     # search as a pear first since most 3rd party channels will report pears as pecls!
     search_cmd = "pear -d preferred_state=#{can_haz(@new_resource, "preferred_state")} search#{expand_channel(can_haz(@new_resource, "channel"))} #{@new_resource.package_name}"
-    if shell_out(search_cmd).stdout.split("\n").find { |line| line =~ /^#{@new_resource.package_name}\s+#{haz_ver(@new_resource, "version")}/ }
+    if shell_out(search_cmd).stdout.split("\n").find { |line| line =~ /^#{@new_resource.package_name}\s+/ }
       false
     else
       # fall back and search as a pecl
       search_cmd = "pecl -d preferred_state=#{can_haz(@new_resource, "preferred_state")} search#{expand_channel(can_haz(@new_resource, "channel"))} #{@new_resource.package_name}"
-      if shell_out(search_cmd).stdout.split("\n").find { |line| line =~ /^#{@new_resource.package_name}\s+#{haz_ver(@new_resource, "version")}/ }
+      if shell_out(search_cmd).stdout.split("\n").find { |line| line =~ /^#{@new_resource.package_name}\s+/ }
         true
       else
         raise "Package #{@new_resource.package_name} not found in either PEAR or PECL."


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2926

When installing a specific pear package version, the package is not recognised due to a faulty regexp.
