### PR TITLE
Set candidate_version to php_pear LWRP's designated version if available.

### DIFF
--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -131,6 +131,7 @@ def current_installed_version
 end
 
 def candidate_version
+  @candidate_version = @new_resource.version
   @candidate_version ||= begin
     candidate_version_cmd = "#{@bin} -d preferred_state=#{can_haz(@new_resource, "preferred_state")} search#{expand_channel(can_haz(@new_resource, "channel"))} #{@new_resource.package_name}"
     p = shell_out(candidate_version_cmd)


### PR DESCRIPTION
Right now, even if a version to upgrade to is _set_ on the resource, `candidate_version` still looks for the most recent version in the repo, and runs the upgrade action if this differs from the `current_resource.version`

I believe this has been broken for a long time, but just finally had the chance to look into it :)
