### PR TITLE
Setting 64-bit support in lib_dir for rhel/fedora correctly (before used).

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,7 @@ default['php']['directives'] = {}
 
 case node["platform_family"]
 when "rhel", "fedora"
+  lib_dir = node['kernel']['machine'] =~ /x86_64/ ? 'lib64' : 'lib'
   default['php']['conf_dir']      = '/etc'
   default['php']['ext_conf_dir']  = '/etc/php.d'
   default['php']['fpm_user']      = 'nobody'
@@ -34,7 +35,6 @@ when "rhel", "fedora"
   else
     default['php']['packages'] = ['php', 'php-devel', 'php-cli', 'php-pear']
   end
-  lib_dir = node['kernel']['machine'] =~ /x86_64/ ? 'lib64' : 'lib'
 when "debian"
   default['php']['conf_dir']      = '/etc/php5/cli'
   default['php']['ext_conf_dir']  = '/etc/php5/conf.d'


### PR DESCRIPTION
Fixed issue where the variable lib_dir is used on line 31 but set (with 64-bit support) on line 37. Now set correctly before used.

Please see this comment and code for more context:
https://github.com/opscode-cookbooks/php/commit/78277fd9e2f02a9ce1f6a59bb64a755fcc4715c5#commitcomment-3283144
