### PR TITLE
[COOK-2926] Use grep_for_version to detect if package is pear/pecl.

### DIFF
--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -250,12 +250,12 @@ def pecl?
   @pecl ||= begin
     # search as a pear first since most 3rd party channels will report pears as pecls!
     search_cmd = "pear -d preferred_state=#{can_haz(@new_resource, "preferred_state")} search#{expand_channel(can_haz(@new_resource, "channel"))} #{@new_resource.package_name}"
-    if shell_out(search_cmd).stdout.split("\n").find { |line| line =~ /^#{@new_resource.package_name}\s+#{haz_ver(@new_resource, "version")}/ }
+    unless grep_for_version(shell_out(search_cmd).stdout, @new_resource.package_name).nil?
       false
     else
       # fall back and search as a pecl
       search_cmd = "pecl -d preferred_state=#{can_haz(@new_resource, "preferred_state")} search#{expand_channel(can_haz(@new_resource, "channel"))} #{@new_resource.package_name}"
-      if shell_out(search_cmd).stdout.split("\n").find { |line| line =~ /^#{@new_resource.package_name}\s+#{haz_ver(@new_resource, "version")}/ }
+      unless grep_for_version(shell_out(search_cmd).stdout, @new_resource.package_name).nil?
         true
       else
         raise "Package #{@new_resource.package_name} not found in either PEAR or PECL."
@@ -268,8 +268,4 @@ end
 # this allows PhpPear to work with Chef::Resource::Package
 def can_haz(resource, attribute_name)
   resource.respond_to?(attribute_name) ? resource.send(attribute_name) : nil
-end
-
-def haz_ver(resource, version)
-  resource.respond_to?(version) ? resource.send(version) : '\d+\.\d+\.\d+'
 end


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2926

grep_for_version will validate that the package is in the pear/pecl channel without failing when the version being installed isn't the latest available.
