### PR TITLE
Adds vagrant kitchen and berkshelf dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Gemfile.lock
 .kitchen
 bin
 .kitchen.local.yml
+.kitchen/

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source :rubygems
 
 gem 'test-kitchen', '< 1.0'
+gem 'kitchen-vagrant', :group => :integration
+gem 'berkshelf'


### PR DESCRIPTION
I needed to add these in order to get kitchen test to actually run.
