### PR TITLE
didn't work with standard ubuntu 12

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -20,6 +20,7 @@
 
 node['php']['packages'].each do |pkg|
   package pkg do
+    package_name pkg
     action :install
   end
 end


### PR DESCRIPTION
chef was looking for a non existing package php5-cgi=5.3.10-1ubuntu3.3 on Ubuntu 12.04 LTS (GNU/Linux 3.2.0-23-generic x86_64)
