### PR TITLE
[COOK-2909] Remove rescue of Chef::Exceptions::ShellCommandFailed.

### DIFF
--- a/providers/pear_channel.rb
+++ b/providers/pear_channel.rb
@@ -86,7 +86,6 @@ def exists?
   begin
     shell_out!("pear channel-info #{@current_resource.channel_name}")
     true
-  rescue Chef::Exceptions::ShellCommandFailed
   rescue Mixlib::ShellOut::ShellCommandFailed
     false
   end


### PR DESCRIPTION
This should never be hit anyway, if we're using a relatively-modern mixlib-shellout.
