### PR TITLE
Remove dependency to windows and iis

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,8 +8,6 @@ version           "1.3.1"
 depends "build-essential"
 depends "xml"
 depends "mysql"
-depends "windows"
-depends "iis"
 
 %w{ debian ubuntu centos redhat fedora scientific amazon windows }.each do |os|
   supports os


### PR DESCRIPTION
We should just use "supports" to not overload cookbooks on plattforms even if they are not needed.
