### PR TITLE
Cannot find a resource for preferred_state

### DIFF
--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -258,13 +258,13 @@ def pecl?
   @pecl ||= begin
               # search as a pear first since most 3rd party channels will report pears as pecls!
               search_cmd = "#{node['php']['pear']} -d"
-              search_cmd << " preferred_state=#{can_haz(@new_resource, preferred_state)}"
+              search_cmd << " preferred_state=#{can_haz(@new_resource, "preferred_state")}"
               search_cmd << " search#{expand_channel(can_haz(@new_resource, "channel"))} #{@new_resource.package_name}"
 
               if grep_for_version(shell_out(search_cmd).stdout, @new_resource.package_name).nil?
                 # fall back and search as a pecl
                 search_cmd = "#{node['php']['pecl']} -d"
-                search_cmd << " preferred_state=#{can_haz(@new_resource, preferred_state)}"
+                search_cmd << " preferred_state=#{can_haz(@new_resource, "preferred_state")}"
                 search_cmd << " search#{expand_channel(can_haz(@new_resource, "channel"))} #{@new_resource.package_name}"
               else
                 false


### PR DESCRIPTION
This fixes an issue when installing `pear` of `pecl` packages i.e. 

```
php_pear 'mongo'
```

output:

```
...
================================================================================
Error executing action `install` on resource 'php_pear[mongo]'
================================================================================


NameError
---------
Cannot find a resource for preferred_state on ubuntu version 12.04


Cookbook Trace:
---------------
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/php/providers/pear.rb:261:in `pecl?'
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/php/providers/pear.rb:105:in `load_current_resource'


Resource Declaration:
---------------------
# In /tmp/vagrant-chef-1/chef-solo-1/cookbooks/sample/recipes/sample.rb

 33:   php_pear pkg
 34: end



Compiled Resource:
------------------
# Declared in /tmp/vagrant-chef-1/chef-solo-1/cookbooks/sample/recipes/sample.rb:33:in `block in from_file'

php_pear("mongo") do
  action :install
  retries 0
  retry_delay 2
  cookbook_name :sample
  recipe_name "sample"
  package_name "mongo"
end
...
```
