### PR TITLE
Pear provider incorrectly considers all packages as PECL

### DIFF
--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -266,14 +266,13 @@ def pecl?
                 search_cmd = "#{node['php']['pecl']} -d"
                 search_cmd << " preferred_state=#{can_haz(@new_resource, "preferred_state")}"
                 search_cmd << " search#{expand_channel(can_haz(@new_resource, "channel"))} #{@new_resource.package_name}"
+                if grep_for_version(shell_out(search_cmd).stdout, @new_resource.package_name).nil?
+                  fail "Package #{@new_resource.package_name} not found in either PEAR or PECL."
+                else
+                  true
+                end
               else
                 false
-              end
-
-              if grep_for_version(shell_out(search_cmd).stdout, @new_resource.package_name).nil?
-                fail "Package #{@new_resource.package_name} not found in either PEAR or PECL."
-              else
-                true
               end
             end
 end


### PR DESCRIPTION
It looks like the pecl? method was modified in this commit: https://github.com/opscode-cookbooks/php/commit/7c336b0bbfaf5806a783ba3524053f27116f6cc1. The refactoring changed the logic flow so that all packages are incorrectly searched for with PECL — even if they were found with Pear — and then, later, the package install action fails because PECL can't install it.

I'm offering this pull request that moves the `if grep_for_version(pecl)` inside the `if grep_for_version(pear).nil?` condition, so that it only searches PECL if/when Pear search fails.
