### PR TITLE
Fix install_packge, so version is correctly used.

### DIFF
--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -146,7 +146,7 @@ def install_package(name, version)
   command << " preferred_state=#{can_haz(@new_resource, "preferred_state")}"
   command << " install -a#{expand_options(@new_resource.options)}"
   command << " #{prefix_channel(can_haz(@new_resource, "channel"))}#{name}"
-  command << " -#{version}" if version && !version.empty?
+  command << "-#{version}" if version && !version.empty?
   pear_shell_out(command)
   manage_pecl_ini(name, :create, can_haz(@new_resource, 'directives'), can_haz(@new_resource, 'zend_extensions')) if pecl?
 end


### PR DESCRIPTION
This is a fix so pear version provided are correctly used on installation.
https://tickets.opscode.com/browse/COOK-4319

For example The resulting command was:

> pear -d preferred_state=stable install -a PHP_CodeSniffer -1.5.1
> But should be:
> pear -d preferred_state=stable install -a PHP_CodeSniffer-1.5.1
