### PR TITLE
Make clean before ./configuration.

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -62,7 +62,7 @@ bash 'build php' do
   cwd Chef::Config[:file_cache_path]
   code <<-EOF
   tar -zxf php-#{version}.tar.gz
-  (cd php-#{version} && make distclean)
+  (cd php-#{version} && make clean)
   (cd php-#{version} && #{ext_dir_prefix} ./configure #{configure_options})
   (cd php-#{version} && make && make install)
   EOF


### PR DESCRIPTION
I ran into the following issue after installing PHP from source and
building the apache libphp5.so module:

```
Restarting web server apache2
apache2: Syntax error on line 185 of /etc/apache2/apache2.conf:
Syntax error on line 1 of /etc/apache2/mods-enabled/php5.load:
Cannot load /usr/lib/apache2/modules/libphp5.so into server:
/usr/lib/apache2/modules/libphp5.so: undefined symbol:
OnUpdateLong
```

As it turns out this can happens under certain circumstances and the
recommended solution is to `make distclean` before attempting to configure
the build.

see: http://serverfault.com/a/148201
