### PR TITLE
Add package options

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -68,6 +68,7 @@ when 'windows'
                                         ext_php_pgsql ext_php_soap ext_php_sockets
                                         ext_php_sqlite3 ext_php_tidy ext_php_xmlrpc
                                       }
+  default['php']['package_options'] = "" # Use this to customise your yum or apt command                                     
   default['php']['pear']          = 'pear.bat'
   default['php']['pecl']          = 'pecl.bat'
 else

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -58,6 +58,7 @@ else
   node['php']['packages'].each do |pkg|
     package pkg do
       action :install
+      options node['php']['package_options']
     end
   end
 end


### PR DESCRIPTION
PR adds the functionality to specify options to the yum command used to install PHP. I've added this because in my org, we use a non-standard PHP (which we install from an internal repo) and have had to re-implement the functionality of package.rb in our wrapper 
