### PR TITLE
Improve PECL package detection and configuration

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -34,10 +34,21 @@ platforms:
     driver:
       ssh:
         shell: '"/bin/sh"'
+
 suites:
   - name: resource_test
     run_list:
       - recipe[test::default]
+  - name: resource_test_peclchannel
+    includes:
+      - ubuntu-16.04
+    run_list:
+      - recipe[test::default]
+    attributes:
+      pecl_method: 'channel'
+    verifier:
+      inspec_tests:
+        - test/integration/resource_test
   - name: source_install
     run_list:
       - recipe[test::source]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It installs and configures PHP and the PEAR package management system. Also incl
 - `node['php']['install_method']` = method to install php with, default `package`.
 - `node['php']['directives']` = Hash of directives and values to append to `php.ini`, default `{}`.
 - `node['php']['pear_setup']` = Boolean value to determine whether to set up pear repositories. Default: `true`
-- `node['php']['pear_channels']` = List of external pear channels to add if `node['php']['pear_setup]` is true. Default: `['pear.php.net', 'pecl.php.net']`
+- `node['php']['pear_channels']` = List of external pear channels to add if `node['php']['pear_setup']` is true. Default: `['pear.php.net', 'pecl.php.net']`
 
 The file also contains the following attribute types:
 
@@ -145,6 +145,18 @@ end
 php_pear 'apc' do
   action :install
   binary 'pear7'
+end
+
+# install sync using the pecl binary
+php_pear 'sync' do
+  version '1.1.1'
+  binary 'pecl'
+end
+
+# install sync using the pecl channel
+php_pear 'sync' do
+  version '1.1.1'
+  channel 'pecl.php.net'
 end
 
 # install the beta version of Horde_Url

--- a/resources/pear.rb
+++ b/resources/pear.rb
@@ -214,7 +214,14 @@ action_class do
   def get_extension_files(name)
     files = []
 
-    p = shell_out("#{new_resource.binary} list-files #{name}")
+    # use appropriate binary when listing pecl packages
+    list_binary = if new_resource.channel == 'pecl.php.net'
+                    node['php']['pecl']
+                  else
+                    new_resource.binary
+                  end
+
+    p = shell_out("#{list_binary} list-files #{name}")
     p.stdout.each_line.grep(/^src\s+.*\.so$/i).each do |line|
       files << line.split[1]
     end
@@ -231,7 +238,11 @@ action_class do
         search_args << " search#{expand_channel(new_resource.channel)} #{new_resource.package_name}"
 
         if grep_for_version(shell_out(new_resource.binary + search_args).stdout, new_resource.package_name)
-          false
+          if (new_resource.binary.include? 'pecl') || (new_resource.channel == 'pecl.php.net')
+            true
+          else
+            false
+          end
         elsif grep_for_version(shell_out(node['php']['pecl'] + search_args).stdout, new_resource.package_name)
           true
         else

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -7,32 +7,23 @@ php_fpm_pool 'test-pool' do
   action :install
 end
 
-# Add a channel
+# Add PEAR channel
 php_pear_channel 'pear.php.net' do
   action :update
 end
 
-# Install a package from the pear.php.net channel
-# http://pear.php.net/package/HTTP2
-php_pear 'HTTP2'
+# Install https://pear.php.net/package/HTTP2
 php_pear 'HTTP2'
 
-php_pear 'Remove it now' do
-  package_name 'HTTP2'
-  action :remove
+# Add PECL channel
+php_pear_channel 'pecl.php.net' do
+  action :update
 end
 
-php_pear 'install the package again' do
-  package_name 'HTTP2'
-  action :install
-end
-
-php_pear 'reinstall the package' do
-  package_name 'HTTP2'
-  action :reinstall
-end
-
-php_pear 'Purge it now' do
-  package_name 'HTTP2'
-  action :purge
+# Install https://pecl.php.net/package/sync
+pecl_method = node['pecl_method'] || 'binary'
+php_pear "sync-#{pecl_method}" do
+  package_name 'sync'
+  binary 'pecl' if pecl_method == 'binary'
+  channel 'pecl.php.net' if pecl_method == 'channel'
 end

--- a/test/integration/resource_test/inspec/php_spec.rb
+++ b/test/integration/resource_test/inspec/php_spec.rb
@@ -10,4 +10,8 @@ describe 'PHP' do
   it 'has the pecl.php.net channel' do
     expect(command('pear list-channels').stdout).to include('pecl.php.net')
   end
+
+  it 'has the PECL sync module' do
+    expect(command('php --ri sync').exit_status).to eq(0)
+  end
 end


### PR DESCRIPTION
### Description

Improve PECL package detection and configuration
* use pecl binary to list files of a pecl package
* fix pecl package detection when using binary or channel method

I chose the `sync` PECL package as it has few dependencies and installs on PHP 5 and higher

### Issues Resolved

Resolves #242
Related to #231

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
  * PASSED `delivery local all`
  * PASSED `resource-test-amazonlinux`
  * FAILED `resource-test-centos-6`: `sync` pecl install failure, ```configure: error: no acceptable C compiler found in $PATH```
  * PASSED `resource-test-centos-7`
  * FAILED `resource-test-debian-8`: `apt-update` failure, Jessie archived, https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html
  * FAILED `resource-test-debian-9`: `sync` PHP module not enabled, fixed by running `phpenmod sync` which is only run for ubuntu
  * PASSED `resource-test-fedora-28`
  * FAILED `resource-test-opensuse-leap-42`: `php-fpm` startup failure, ```ERROR: failed to load configuration file '/etc/php5/fpm/php-fpm.conf'```
  * PASSED `resource-test-ubuntu-1404`
  * PASSED `resource-test-ubuntu-1604`
  * PASSED `resource-test-ubuntu-1804`
  * FAILED `resource-test-ubuntu-1604-chef-127`: `build-essential` requires `seven_zip`, `seven_zip` requires Chef 13+
  * FAILED `resource-test-freebsd-10`: `pear` package not found, looks like it should be `devel/pear`
  * FAILED `resource-test-freebsd-11`: `php56` package not found, should be one of `php71`, `php72`, `php73`
  * FAILED `source-install-amazonlinux`: ```No such file or directory - /usr/bin/pear```, installed at `/usr/local/bin/pear`
  * FAILED `source-install-centos-6`: ```No such file or directory - /usr/bin/pear```, installed at `/usr/local/bin/pear`
  * SKIPPED all remaining `source-install` tests
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>