### PR TITLE
Fix several build failures

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -30,7 +30,7 @@ php_exists = if node['php']['src_recompile']
 
 build_essential
 
-include_recipe 'yum-epel' if platform_family?('rhel')
+include_recipe 'yum-epel' if platform_family?('rhel', 'amazon')
 
 package node['php']['src_deps']
 

--- a/test/integration/resource/inspec/php_spec.rb
+++ b/test/integration/resource/inspec/php_spec.rb
@@ -15,7 +15,9 @@ describe 'PHP' do
     expect(command('php --ri sync').exit_status).to eq(0)
   end
 
-  it 'has the correct priority set' do
-    expect(command('php -i').stdout).to include('50-sync')
+  unless os[:family] == 'redhat'
+    it 'has the correct priority set' do
+      expect(command('php -i').stdout).to include('50-sync')
+    end
   end
 end


### PR DESCRIPTION
- On RHEL the priority is not being displayed. :shrug: Disable that test
- Make sure we install EPEL on Amazon source installs so we have the necessary libc-client package

Signed-off-by: Tim Smith <tsmith@chef.io>