### PR TITLE
Drop support for building source on Debian 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
         suite:
           - 'resource'
           - 'source-install'
+        exclude:
+          - os: debian-9
+            suite: source-install
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in each version of the PHP cookbook.
 
 - Add support for Ubuntu 20.04
 - Refactor version conditionals to use `Chef::VersionConstraint`
+- Only symlink GMP on Ubuntu 16.04 to aid source builds
 
 ## 7.2.0 (2020-06-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is used to list changes made in each version of the PHP cookbook.
 - Add support for Ubuntu 20.04
 - Refactor version conditionals to use `Chef::VersionConstraint`
 - Only symlink GMP on Ubuntu 16.04 to aid source builds
+- Drop support for installing from source on Debian 9
 
 ## 7.2.0 (2020-06-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ This file is used to list changes made in each version of the PHP cookbook.
 ## Unreleased
 
 - Add support for Ubuntu 20.04
-- Refactor version conditionals to use `Chef::VersionConstraint`
 - Only symlink GMP on Ubuntu 16.04 to aid source builds
 - Drop support for installing from source on Debian 9
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ This recipe installs PHP from packages.
 
 This recipe installs PHP from source.
 
+*Note:* Debian 9 is not supported for building from source.
+
 ## Usage
 
 Simply include the `php` recipe where ever you would like php installed. To install from source override the `node['php']['install_method']` attribute with in a role or wrapper cookbook:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -36,3 +36,5 @@ suites:
   - name: source_install
     run_list:
       - recipe[test::source]
+    excludes:
+      - debian-9

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -60,11 +60,11 @@ if node['php']['ext_dir']
   end
 end
 
-# PHP is unable to find the GMP library in 16.04. The symlink brings the file
-# inside of the include libraries.
+# PHP is unable to find the GMP library on Ubuntu 16.04
+# This symlink brings the file inside of the included libraries
 link '/usr/include/gmp.h' do
   to '/usr/include/x86_64-linux-gnu/gmp.h'
-  only_if { platform?('ubuntu') }
+  only_if { platform?('ubuntu') && node['platform_version'].to_f == 16.04 }
 end
 
 execute 'clean build' do

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -18,6 +18,10 @@
 # limitations under the License.
 #
 
+if platform?('debian') && node['platform_version'].to_i == 9
+  Chef::Log.fatal 'Debian 9 is not supported when building from source'
+end
+
 version = node['php']['version']
 configure_options = node['php']['configure_options'].join(' ')
 ext_dir_prefix = node['php']['ext_dir'] ? "EXTENSION_DIR=#{node['php']['ext_dir']}" : ''


### PR DESCRIPTION
## Description

Drops support for building PHP from source on Debian 9. It’s got some strange failures, and providing meaningful support for package install, and source support otherwise, is a sensible step forward.

## Issues Resolved

None

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
