### PR TITLE
fix: Prevent Apache from being pulled in as a dep on Ubuntu 20.04 (#311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the PHP cookbook.
 
+## Unreleased
+
+- Prevent Apache from being pulled in as a dependency on Ubuntu 20.04 (#311)
+
 ## 8.0.0 (2020-07-09)
 
 - Drop support for:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -127,8 +127,7 @@ when 'debian'
     default['php']['checksum']         = 'a554a510190e726ebe7157fb00b4aceabdb50c679430510a3b93cbf5d7546e44'
     default['php']['conf_dir']         = '/etc/php/7.4/cli'
     default['php']['src_deps']         = %w(libbz2-dev libc-client2007e-dev libcurl4-gnutls-dev libfreetype6-dev libgmp3-dev libjpeg62-dev libkrb5-dev libmcrypt-dev libpng-dev libssl-dev pkg-config libxml2-dev libsqlite3-dev libonig-dev)
-    # Ubuntu >= 20.04 drops versions from the package names
-    default['php']['packages']         = %w(php-cgi php php-dev php-cli php-pear)
+    default['php']['packages']         = %w(php7.4-cgi php7.4 php7.4-dev php7.4-cli php-pear)
     default['php']['fpm_package']      = 'php7.4-fpm'
     default['php']['fpm_pooldir']      = '/etc/php/7.4/fpm/pool.d'
     default['php']['fpm_service']      = 'php7.4-fpm'

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -68,7 +68,7 @@ describe 'php::default' do
   context 'on ubuntu 20.04' do
     platform 'ubuntu', '20.04'
 
-    let(:packages) { %w(php-cgi php php-dev php-cli php-pear) }
+    let(:packages) { ['php7.4-cgi', 'php7.4', 'php7.4-dev', 'php7.4-cli', 'php-pear'] }
     let(:php_ini_path) { '/etc/php/7.4/cli/php.ini' }
 
     it_should_behave_like 'php'

--- a/test/integration/resource/inspec/php_spec.rb
+++ b/test/integration/resource/inspec/php_spec.rb
@@ -21,3 +21,10 @@ describe 'PHP' do
     end
   end
 end
+
+# Check if we didn't accidentally pull in Apache as a dependency (#311)
+unless os[:family] == 'redhat'
+  describe package('apache2') do
+    it { should_not be_installed }
+  end
+end


### PR DESCRIPTION
# Description

This PR prevents Apache from being pulled in as a dependency on Ubuntu 20.04.

A unit test could be added to make sure Apache doesn't get installed, but i didn't go that far.

## Issues Resolved

#311 

## Check List

- [X] All tests pass. See TESTING.md for details.
- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
