### PR TITLE
Add community repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the PHP cookbook.
 
+## Unreleased
+
+- Add ability to use community repositories to install newer versions of PHP
+
 ## 8.0.1 (2020-11-12)
 
 - Prevent Apache from being pulled in as a dependency on Ubuntu 20.04 (#311)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ Include the default recipe in a run list, to get `php`. By default `php` is inst
 
 This recipe installs PHP from packages.
 
+### community_package
+
+This recipe intalls PHP from one of two available community package repositories, depending on platform family. This provides the ability to install PHP versions that are no provided by the official distro repositories.
+
+Set `node['php']['install_method'] = 'community_package'` to use these repositories.
+
+Please see `test/cookbooks/test/recipes/community.rb` for an example of how to use attributes to install the desired version of PHP & its supporting packages, and please refer to the documentation on these community repositories:
+
+- RHEL/Amazon - [Remi’s RPM repository](https://rpms.remirepo.net)
+- Debian - [Ondřej Surý PPA](https://launchpad.net/~ondrej/+archive/ubuntu/php)
+
 ### source
 
 This recipe installs PHP from source.
@@ -62,7 +73,7 @@ This recipe installs PHP from source.
 
 ## Usage
 
-Simply include the `php` recipe where ever you would like php installed. To install from source override the `node['php']['install_method']` attribute with in a role or wrapper cookbook:
+Simply include the `php` recipe where ever you would like php installed. To install from source override the `node['php']['install_method']` attribute within a role or wrapper cookbook:
 
 ### Role example
 

--- a/documentation/php_fpm_pool.md
+++ b/documentation/php_fpm_pool.md
@@ -4,7 +4,7 @@ Installs the `php-fpm` package appropriate for your distro (if using packages) a
 
 Please consider FPM functionally pre-release, and test it thoroughly in your environment before using it in production
 
-More info: <http://php.net/manual/en/install.fpm.php>
+More info: <https://www.php.net/manual/en/install.fpm.php>
 
 ## Actions
 
@@ -19,7 +19,7 @@ More info: <http://php.net/manual/en/install.fpm.php>
 | `listen`            | `String` | Default: `/var/run/php5-fpm.sock`    | The listen address                                                                    |
 | `user`              |          | The webserver user for your distro.  | The user to run the FPM under                                                         |
 | `group`             |          | The webserver group for your distro. | The group to run the FPM under                                                        |
-| `process_manager`   |          | `dynamic`                            | Process manager to use - see <http://php.net/manual/en/install.fpm.configuration.php> |
+| `process_manager`   |          | `dynamic`                            | Process manager to use - see <https://www.php.net/manual/en/install.fpm.configuration.php> |
 | `max_children`      |          | `5`                                  | Max children to scale to                                                              |
 | `start_servers`     |          | `2`                                  | Number of servers to start the pool with                                              |
 | `min_spare_servers` |          | `1`                                  | Minimum number of servers to have as spares                                           |

--- a/documentation/php_fpm_pool.md
+++ b/documentation/php_fpm_pool.md
@@ -3,7 +3,7 @@
 Installs the `php-fpm` package appropriate for your distro (if using packages) and configures a FPM pool for you. Currently only supported in Debian-family operating systems and CentOS 7 (or at least tested with such, YMMV if you are using source).
 
 Please consider FPM functionally pre-release, and test it thoroughly in your environment before using it in production
-
+<!-- markdown-link-check-disable -->
 More info: <https://www.php.net/manual/en/install.fpm.php>
 
 ## Actions

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -23,6 +23,9 @@ suites:
   - name: resource
     run_list:
       - recipe[test::default]
+  - name: resource_community
+    run_list:
+      - recipe[test::community]
   - name: resource_peclchannel
     includes:
       - ubuntu-16.04

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,8 @@ chef_version      '>= 14.0'
 version           '8.0.1'
 
 depends 'yum-epel'
+depends 'yum-remi-chef'
+depends 'ondrej_ppa_ubuntu'
 
 supports 'amazon', '>= 2.0'
 supports 'centos', '>= 7.0'

--- a/recipes/community_package.rb
+++ b/recipes/community_package.rb
@@ -1,0 +1,27 @@
+#
+# Author::  Jeff Byrnes (<thejeffbyrnes@gmail.com>)
+# Cookbook:: php
+# Recipe:: package
+#
+# Copyright:: 2021, Jeff Byrnes
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if platform_family?('rhel', 'amazon')
+  include_recipe 'yum-remi-chef::remi'
+elsif platform_family?('debian')
+  include_recipe 'ondrej_ppa_ubuntu'
+end
+
+include_recipe 'php::package'

--- a/test/cookbooks/test/recipes/community.rb
+++ b/test/cookbooks/test/recipes/community.rb
@@ -1,0 +1,75 @@
+node.default['php']['fpm_ini_control'] = false
+
+if platform_family?('rhel', 'amazon')
+  node.default['php']['packages']         = %w(php80 php80-php-devel php80-php-cli php80-php-pear)
+  node.default['php']['fpm_package']      = 'php80-php-fpm'
+  node.default['php']['fpm_service']      = 'php80-php-fpm'
+  node.default['php']['pear']             = '/usr/bin/php80-pear'
+  node.default['php']['conf_dir']         = '/etc/opt/remi/php80'
+  node.default['php']['ext_conf_dir']     = '/etc/opt/remi/php80/php.d'
+  node.default['php']['fpm_pooldir']      = '/etc/opt/remi/php80/php-fpm.d'
+  node.default['php']['fpm_default_conf'] = '/etc/opt/remi/php80/php-fpm.d/www.conf'
+
+  lib_dir = node['kernel']['machine'] =~ /x86_64/ ? 'lib64' : 'lib'
+  node.default['php']['ext_dir'] = "/opt/remi/php80/root/#{lib_dir}/php/modules"
+elsif platform_family?('debian')
+  node.default['php']['packages']    = %w(php8.0-cgi php8.0 php8.0-dev php8.0-cli php-pear)
+  node.default['php']['fpm_package'] = 'php8.0-fpm'
+end
+
+node.default['php']['install_method'] = 'community_package'
+
+apt_update 'update'
+
+include_recipe 'php'
+
+# README: The Remi repo intentionally avoids installing the binaries to
+#         the default paths. It comes with a /opt/remi/php80/enable profile
+#         which can be copied or linked into /etc/profiles.d to auto-load for
+#         operators in a real cookbook.
+if platform_family?('rhel', 'amazon')
+  link '/usr/bin/php' do
+    to '/usr/bin/php80'
+  end
+
+  link '/usr/bin/php-pear' do
+    to '/usr/bin/php80-pear'
+  end
+
+  link '/usr/bin/pecl' do
+    to '/opt/remi/php80/root/bin/pecl'
+  end
+
+  link '/etc/profile.d/php80-enable.sh' do
+    to '/opt/remi/php80/enable'
+  end
+end
+
+# Create a test pool
+php_fpm_pool 'test-pool' do
+  action :install
+end
+
+# Add PEAR channel
+php_pear_channel 'pear.php.net' do
+  binary node['php']['pear']
+  action :update
+end
+
+# Install https://pear.php.net/package/HTTP2
+php_pear 'HTTP2' do
+  binary node['php']['pear']
+end
+
+# Add PECL channel
+php_pear_channel 'pecl.php.net' do
+  binary node['php']['pear']
+  action :update
+end
+
+# Install https://pecl.php.net/package/sync
+php_pear 'sync-binary' do
+  package_name 'sync'
+  binary 'pecl'
+  priority '50'
+end

--- a/test/integration/resource_community/inspec/php_spec.rb
+++ b/test/integration/resource_community/inspec/php_spec.rb
@@ -1,0 +1,30 @@
+describe 'PHP' do
+  it 'has PHP 8.0' do
+    expect(command('php -v').stdout).to match(/PHP 8.0/)
+  end
+
+  it 'has the pear.php.net channel' do
+    expect(command('php-pear list-channels').stdout).to include('pear.php.net')
+  end
+
+  it 'has the pecl.php.net channel' do
+    expect(command('php-pear list-channels').stdout).to include('pecl.php.net')
+  end
+
+  it 'has the PECL sync module' do
+    expect(command('php --ri sync').exit_status).to eq(0)
+  end
+
+  unless os[:family] == 'redhat'
+    it 'has the correct priority set' do
+      expect(command('php -i').stdout).to include('50-sync')
+    end
+  end
+end
+
+# Check if we didn't accidentally pull in Apache as a dependency (#311)
+unless os[:family] == 'redhat'
+  describe package('apache2') do
+    it { should_not be_installed }
+  end
+end


### PR DESCRIPTION
## Description

Add ability to use community-supported repositories (PPA for Debian systems, custom RPM for Red Hat/Amazon) to install more recent versions of PHP.

## Issues Resolved

Fixes #224 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
