### PR TITLE
Fix community package install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of the PHP cookbook.
 
 ## Unreleased
 
+- Reenable community package recipe for CentOS 8
+  - Bumps `yum-remi-chef` dependency to >= 5.0.1
+
 ## 9.0.0 - *2021-09-08*
 
 - Enable `unified_mode` for Chef 17 compatibility

--- a/README.md
+++ b/README.md
@@ -56,17 +56,15 @@ This recipe installs PHP from packages.
 
 ### community_package
 
-This recipe intalls PHP from one of two available community package repositories, depending on platform family. This provides the ability to install PHP versions that are no provided by the official distro repositories.
+This recipe installs PHP from one of two available community package repositories, depending on platform family. This provides the ability to install PHP versions that are no provided by the official distro repositories.
 
 Set `node['php']['install_method'] = 'community_package'` to use these repositories.
 
 Please see `test/cookbooks/test/recipes/community.rb` for an example of how to use attributes to install the desired version of PHP & its supporting packages, and please refer to the documentation on these community repositories:
 
-- CentOS 7 / Amazon 2 - [Remi’s RPM repository](https://rpms.remirepo.net)
+- CentOS - [Remi’s RPM repository](https://rpms.remirepo.net)
 - Ubuntu - [Ondřej Surý PPA](https://launchpad.net/~ondrej/+archive/ubuntu/php)
 - Debian - [Sury repo](https://deb.sury.org/)
-
-> ⚠ This recipe does not support CentOS 8! Chef does not currently support module streams required for the REMI repo on C8
 
 ### source
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,7 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_zero
+  name: chef_infra
   product_name: chef
   chef_license: accept-no-persist
   enforce_idempotency: true
@@ -29,8 +29,6 @@ suites:
   - name: resource_community
     run_list:
       - recipe[test::community]
-    excludes:
-      - centos-8 # no support for dnf modules currently
   - name: resource_peclchannel
     run_list:
       - recipe[test::default]

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ chef_version      '>= 15.3'
 
 depends 'ondrej_ppa_ubuntu'
 depends 'yum-epel'
-depends 'yum-remi-chef'
+depends 'yum-remi-chef', '>= 5.0.1'
 
 supports 'amazon', '>= 2.0'
 supports 'centos', '>= 7.0'

--- a/recipes/community_package.rb
+++ b/recipes/community_package.rb
@@ -19,9 +19,6 @@
 #
 
 if platform_family?('rhel', 'amazon')
-  raise 'php::community_package does not support CentOS 8! Chef does not currently have support ' \
-  'for DNF streams required to enable the REMI repo on C8' if node['platform_version'].to_i >= 8
-
   include_recipe 'yum-remi-chef::remi'
 elsif platform?('ubuntu')
   include_recipe 'ondrej_ppa_ubuntu'


### PR DESCRIPTION
# Description

Updates as part of sous-chefs/yum-remi-chef#37 broke community package installs on non-RHEL systems (thanks attributes). This was fixed in sous-chefs/yum-remi-chef#39, so this PR bumps the required version to at least that.

Also re-enabled CentOS 8 community package support as `yum-remi-chef` now works on C8.

## Issues Resolved

sous-chefs/yum-remi-chef#38

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
