### PR TITLE
Update tested platforms & remove Delivery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           - centos-8
           - debian-9
           - debian-10
+          - debian-11
           - ubuntu-1804
           - ubuntu-2004
         suite:
@@ -55,8 +56,6 @@ jobs:
         exclude:
           - os: debian-9
             suite: source-install
-          - os: centos-8
-            suite: resource-community
       fail-fast: false
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,44 +8,22 @@ name: ci
       - main
 
 jobs:
-  delivery:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Chef Delivery
-        uses: actionshub/chef-delivery@main
-        env:
-          CHEF_LICENSE: accept-no-persist
-
-  yamllint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run yaml Lint
-        uses: actionshub/yamllint@main
-
-  mdl:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Markdown Lint
-        uses: actionshub/markdownlint@main
+  lint-unit:
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.3
 
   integration:
-    needs: [mdl, yamllint, delivery]
+    needs: lint-unit
     runs-on: ubuntu-latest
     strategy:
       matrix:
         os:
+          - almalinux-8
           - amazonlinux-2
           - centos-7
-          - centos-8
-          - debian-9
+          - centos-stream-8
           - debian-10
           - debian-11
+          - rockylinux-8
           - ubuntu-1804
           - ubuntu-2004
         suite:
@@ -53,9 +31,6 @@ jobs:
           - resource-community
           - resource-peclchannel
           - source-install
-        exclude:
-          - os: debian-9
-            suite: source-install
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file is used to list changes made in each version of the PHP cookbook.
 
 ## Unreleased
 
+- Switch to using reusable CI workflow
+- Update tested platforms
+  - removed: CentOS 8, Debian 9
+  - added: CentOS Stream 8, Rocky / Alma 8, Debian 11
+
 ## 9.1.1 - *2022-02-08*
 
 - Remove delivery folder

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ### Platforms
 
-- Debian, Ubuntu
-- CentOS, Red Hat, Oracle, Scientific, Amazon Linux
-- Fedora
+- Ubuntu 18.04 / 20.04
+- Debian 10 / 11
+- CentOS 7+ (incl. Alma & Rocky)
 
 ### Chef
 
@@ -46,15 +46,15 @@ This cookbook includes resources for managing:
 
 ## Recipes
 
-### default
+### `php::default`
 
 Include the default recipe in a run list, to get `php`. By default `php` is installed from packages but this can be changed by using the `install_method` attribute.
 
-### package
+### `php::package`
 
 This recipe installs PHP from packages.
 
-### community_package
+### `php::community_package`
 
 This recipe installs PHP from one of two available community package repositories, depending on platform family. This provides the ability to install PHP versions that are no provided by the official distro repositories.
 
@@ -66,11 +66,9 @@ Please see `test/cookbooks/test/recipes/community.rb` for an example of how to u
 - Ubuntu - [Ondřej Surý PPA](https://launchpad.net/~ondrej/+archive/ubuntu/php)
 - Debian - [Sury repo](https://deb.sury.org/)
 
-### source
+### `php::source`
 
 This recipe installs PHP from source.
-
-*Note:* Debian 9 is not supported for building from source.
 
 ## Usage
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -95,7 +95,7 @@ when 'debian'
   default['php']['fpm_listen_user']  = 'www-data'
   default['php']['fpm_listen_group'] = 'www-data'
 
-  if platform?('debian') && node['platform_version'].to_i >= 10
+  if platform?('debian') && node['platform_version'].to_i == 10
     default['php']['version']          = '7.3.19'
     default['php']['checksum']         = '809126b46d62a1a06c2d5a0f9d7ba61aba40e165f24d2d185396d0f9646d3280'
     default['php']['conf_dir']         = '/etc/php/7.3/cli'
@@ -109,6 +109,19 @@ when 'debian'
     default['php']['fpm_default_conf'] = '/etc/php/7.3/fpm/pool.d/www.conf'
     default['php']['fpm_conf_dir']     = '/etc/php/7.3/fpm'
     default['php']['ext_conf_dir']     = '/etc/php/7.3/mods-available'
+  elsif platform?('debian') && node['platform_version'].to_i >= 11
+    default['php']['version']          = '7.4.27'
+    default['php']['checksum']         = '564fd5bc9850370db0cb4058d9087f2f40177fa4921ce698a375416db9ab43ca'
+    default['php']['conf_dir']         = '/etc/php/7.4/cli'
+    default['php']['src_deps']         = %w(libbz2-dev libc-client2007e-dev libcurl4-gnutls-dev libfreetype6-dev libgmp3-dev libjpeg62-turbo-dev libkrb5-dev libmcrypt-dev libonig-dev libpng-dev libsqlite3-dev libssl-dev pkg-config libxml2-dev file re2c libzip-dev)
+    default['php']['packages']         = %w(php-cgi php php-dev php-cli php-pear)
+    default['php']['fpm_package']      = 'php7.4-fpm'
+    default['php']['fpm_pooldir']      = '/etc/php/7.4/fpm/pool.d'
+    default['php']['fpm_service']      = 'php7.4-fpm'
+    default['php']['fpm_socket']       = '/var/run/php/php7.4-fpm.sock'
+    default['php']['fpm_default_conf'] = '/etc/php/7.4/fpm/pool.d/www.conf'
+    default['php']['fpm_conf_dir']     = '/etc/php/7.4/fpm'
+    default['php']['ext_conf_dir']     = '/etc/php/7.4/mods-available'
   elsif platform?('ubuntu') && node['platform_version'].to_f == 18.04
     default['php']['version']          = '7.2.31'
     default['php']['checksum']         = '796837831ccebf00dc15921ed327cfbac59177da41b33044d9a6c7134cdd250c'

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -3,64 +3,59 @@ driver:
   name: dokken
   privileged: true
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
-  env: [CHEF_LICENSE=accept]
 
 transport:
   name: dokken
 
 provisioner:
   name: dokken
+  chef_license: accept-no-persist
 
 verifier:
   name: inspec
 
 platforms:
+  - name: almalinux-8
+    driver:
+      image: dokken/almalinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: amazonlinux-2
     driver:
       image: dokken/amazonlinux-2
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: debian-9
-    driver:
-      image: dokken/debian-9
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-
   - name: debian-10
     driver:
       image: dokken/debian-10
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
   - name: debian-11
     driver:
       image: dokken/debian-11
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
   - name: centos-7
     driver:
       image: dokken/centos-7
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-8
+  - name: centos-stream-8
     driver:
-      image: dokken/centos-8
+      image: dokken/centos-stream-8
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: ubuntu-18.04
     driver:
       image: dokken/ubuntu-18.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
   - name: ubuntu-20.04
     driver:
       image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
+
+  - name: rockylinux-8
+    driver:
+      image: dokken/rockylinux-8
+      pid_one_command: /usr/lib/systemd/systemd

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -34,6 +34,13 @@ platforms:
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
 
+  - name: debian-11
+    driver:
+      image: dokken/debian-11
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+
   - name: centos-7
     driver:
       image: dokken/centos-7

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -14,10 +14,10 @@ verifier:
   name: inspec
 
 platforms:
+  - name: almalinux-8
   - name: amazonlinux-2
   - name: centos-7
-  - name: centos-8
-  - name: debian-9
+  - name: centos-stream-8
   - name: debian-10
   - name: debian-11
   - name: ubuntu-18.04
@@ -41,5 +41,3 @@ suites:
   - name: source_install
     run_list:
       - recipe[test::source]
-    excludes:
-      - debian-9

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -19,6 +19,7 @@ platforms:
   - name: centos-8
   - name: debian-9
   - name: debian-10
+  - name: debian-11
   - name: ubuntu-18.04
   - name: ubuntu-20.04
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,7 +14,7 @@ depends 'yum-remi-chef', '>= 5.0.1'
 
 supports 'amazon', '>= 2.0'
 supports 'centos', '>= 7.0'
-supports 'debian', '>= 9.0'
+supports 'debian', '>= 10.0'
 supports 'oracle', '>= 7.0'
 supports 'redhat', '>= 7.0'
 supports 'scientific', '>= 7.0'

--- a/test/cookbooks/test/recipes/community.rb
+++ b/test/cookbooks/test/recipes/community.rb
@@ -13,15 +13,15 @@ if platform_family?('rhel', 'amazon')
   lib_dir = node['kernel']['machine'] =~ /x86_64/ ? 'lib64' : 'lib'
   node.default['php']['ext_dir'] = "/opt/remi/php80/root/#{lib_dir}/php/modules"
 elsif platform_family?('debian')
-  node.default['php']['packages']         = %w(php8.0 php8.0-cgi php8.0-cli php8.0-dev php-pear)
-  node.default['php']['conf_dir']         = '/etc/php/8.0/'
-  node.default['php']['ext_conf_dir']     = '/etc/php/8.0/mods-available'
-  node.default['php']['fpm_package']      = 'php8.0-fpm'
-  node.default['php']['fpm_service']      = 'php8.0-fpm'
-  node.default['php']['fpm_conf_dir']     = '/etc/php/8.0/fpm'
-  node.default['php']['fpm_pooldir']      = '/etc/php/8.0/fpm/pool.d'
-  node.default['php']['fpm_default_conf'] = '/etc/php/8.0/fpm/pool.d/www.conf'
-  node.default['php']['fpm_socket']       = '/var/run/php/php8.0-fpm.sock'
+  node.default['php']['packages']         = %w(php8.1 php8.1-cgi php8.1-cli php8.1-dev php-pear)
+  node.default['php']['conf_dir']         = '/etc/php/8.1/'
+  node.default['php']['ext_conf_dir']     = '/etc/php/8.1/mods-available'
+  node.default['php']['fpm_package']      = 'php8.1-fpm'
+  node.default['php']['fpm_service']      = 'php8.1-fpm'
+  node.default['php']['fpm_conf_dir']     = '/etc/php/8.1/fpm'
+  node.default['php']['fpm_pooldir']      = '/etc/php/8.1/fpm/pool.d'
+  node.default['php']['fpm_default_conf'] = '/etc/php/8.1/fpm/pool.d/www.conf'
+  node.default['php']['fpm_socket']       = '/var/run/php/php8.1-fpm.sock'
 end
 
 node.default['php']['install_method'] = 'community_package'

--- a/test/integration/resource_community/inspec/php_spec.rb
+++ b/test/integration/resource_community/inspec/php_spec.rb
@@ -1,6 +1,6 @@
 describe command('php -v') do
   its('exit_status') { should eq 0 }
-  its('stdout') { should match /PHP 8.0/ }
+  its('stdout') { should match /PHP 8/ }
 end
 
 pear_cmd = os.debian? ? 'pear' : 'php-pear'


### PR DESCRIPTION
# Description

- Remove delivery and switch to using reusable CI workflow
- Update tested platforms
  - removed: CentOS 8, Debian 9
  - added: CentOS Stream 8, Rocky / Alma 8, Debian 11
- Add source install attributes for Debian 11

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
