### PR TITLE
Fix Typos in Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the PHP cookbook.
 
 ## Unreleased
 
+- Fix typos in documentation for `php_install` and `php_ini` resources
+
 ## 10.0.1 - *2024-05-23*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/documentation/php_ini.md
+++ b/documentation/php_ini.md
@@ -1,4 +1,4 @@
-# `php_install`
+# `php_ini`
 
 Adds a `php.ini` to the appropriate location.
 

--- a/documentation/php_ini.md
+++ b/documentation/php_ini.md
@@ -11,8 +11,8 @@ Adds a `php.ini` to the appropriate location.
 
 | Name                | Type             | Default                                               | Description                                                 |
 | ------------------- | ---------------- | ----------------------------------------------------- | ----------------------------------------------------------- |
-| `conf_dir`          | `String`         | Platform-specific - see `libraries/helpers.rb         | Directory to place the `php.ini` file under                 |
-| `ini_template       | `String`         | `php.ini.erb` (see `templates/<distro>/php.ini.rb`)   | Template to use to create the `php.ini` file                |
+| `conf_dir`          | `String`         | Platform-specific - see `libraries/helpers.rb`        | Directory to place the `php.ini` file under                 |
+| `ini_template`      | `String`         | `php.ini.erb` (see `templates/<distro>/php.ini.rb`)   | Template to use to create the `php.ini` file                |
 | `ini_cookbook`      | `String`         | `php` (this cookbook)                                 | Cookbook where the template is located                      |
 | `directives`        | `Hash`           | `{}`                                                  | Directive-value pairs to add to the `php.ini` file          |
 | `ext_dir`           | `String`         | Platform-specific - see `libraries/helpers.rb`        | Directory in which the loadable extensions (modules) reside |

--- a/documentation/php_install.md
+++ b/documentation/php_install.md
@@ -10,13 +10,13 @@ By default, installs the `php` packages appropriate for your platform and adds a
 
 | Name                | Type             | Default                                               | Description                                                 |
 | ------------------- | ---------------- | ----------------------------------------------------- | ----------------------------------------------------------- |
-| `packages`          | `String`         | Platform-specific - see `libraries/helpers.rb`        | Packages to install                                         |
-| `options`           | `[String, Array] |                                                       | Installation options (see Chef `package` resource)          |
-| `conf_dir`          | `String`         | Platform-specific - see `libraries/helpers.rb         | Directory to place the `php.ini` file under                 |
-| `ini_template       | `String`         | `php.ini.erb` (see `templates/<distro>/php.ini.rb`)   | Template to use to create the `php.ini` file                |
-| `ini_cookbook`      | `String`         | `php` (this cookbook)                                 | Cookbook where the template is located                      |
-| `directives`        | `Hash`           | `{}`                                                  | Directive-value pairs to add to the `php.ini` file          |
-| `ext_dir`           | `String`         | Platform-specific - see `libraries/helpers.rb`        | Directory in which the loadable extensions (modules) reside |
+| `packages`          | `String`          | Platform-specific - see `libraries/helpers.rb`        | Packages to install                                         |
+| `options`           | `[String, Array]` |                                                       | Installation options (see Chef `package` resource)          |
+| `conf_dir`          | `String`          | Platform-specific - see `libraries/helpers.rb`        | Directory to place the `php.ini` file under                 |
+| `ini_template`      | `String`          | `php.ini.erb` (see `templates/<distro>/php.ini.rb`)   | Template to use to create the `php.ini` file                |
+| `ini_cookbook`      | `String`          | `php` (this cookbook)                                 | Cookbook where the template is located                      |
+| `directives`        | `Hash`            | `{}`                                                  | Directive-value pairs to add to the `php.ini` file          |
+| `ext_dir`           | `String`          | Platform-specific - see `libraries/helpers.rb`        | Directory in which the loadable extensions (modules) reside |
 
 ## Examples
 


### PR DESCRIPTION
# Description

Fixes unclosed code formatting in docs for `php_install` and `php_ini`; fixes fitle for `php_ini` doc.

## Issues Resolved

None

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing. _<-- N/A_
- [x] New functionality has been documented in the README if applicable. _<--N/A_
