### PR TITLE
Add correct version of php for el9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This file is used to list changes made in each version of the PHP cookbook.
 
 Standardise files with files in sous-chefs/repo-management
 
+- Correct the php version for rhel9. Visible in the fpm pool
+
 ## 10.0.2 - *2024-05-23*
 
 - Fix typos in documentation for `php_install` and `php_ini` resources

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -147,7 +147,12 @@ module Php
       def php_version
         case node['platform_family']
         when 'rhel'
-          '7.2'
+          case node['platform_version'].to_i
+          when 9
+            '8.0'
+          else
+            '7.2'
+          end
         when 'amazon'
           '8.2'
         when 'debian'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -147,8 +147,7 @@ module Php
       def php_version
         case node['platform_family']
         when 'rhel'
-          case node['platform_version'].to_i
-          when 9
+          if node['platform_version'].to_i >= 9
             '8.0'
           else
             '7.2'


### PR DESCRIPTION
# Description

Correct the php version used on rhel 9. This is visible in the fpm pool

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
