### PR TITLE
chore: delay php-fpm service restart upon configuration update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file is used to list changes made in each version of the PHP cookbook.
 
 ## Unreleased
+
 ## 10.1.2 - *2024-11-06*
 
 - delay `phpX.Y-fpm` service restart upon configuration update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ This file is used to list changes made in each version of the PHP cookbook.
 
 - delay `phpX.Y-fpm` service restart upon configuration update
 
----
-
 ## 10.1.1 - *2024-08-01*
 
 - resolved cookstyle error: metadata.rb:14:20 refactor: `Chef/Correctness/SupportsMustBeFloat`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This file is used to list changes made in each version of the PHP cookbook.
 
 ## Unreleased
+## 10.1.2 - *2024-11-06*
+
+- delay `phpX.Y-fpm` service restart upon configuration update
+
+---
 
 ## 10.1.1 - *2024-08-01*
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license           'Apache-2.0'
 description       'Installs and maintains php and php modules'
 source_url        'https://github.com/sous-chefs/php'
 issues_url        'https://github.com/sous-chefs/php/issues'
-version           '10.1.2'
+version           '10.1.1'
 chef_version      '>= 15.3'
 
 supports 'amazon', '>= 2.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license           'Apache-2.0'
 description       'Installs and maintains php and php modules'
 source_url        'https://github.com/sous-chefs/php'
 issues_url        'https://github.com/sous-chefs/php/issues'
-version           '10.1.1'
+version           '10.1.2'
 chef_version      '>= 15.3'
 
 supports 'amazon', '>= 2.0'

--- a/resources/fpm_pool.rb
+++ b/resources/fpm_pool.rb
@@ -85,7 +85,7 @@ action :install do
       fpm_pool_chdir: new_resource.chdir,
       fpm_pool_additional_config: new_resource.additional_config
     )
-    notifies :restart, "service[#{new_resource.service}]"
+    notifies :restart, "service[#{new_resource.service}]", :delayed
   end
 end
 


### PR DESCRIPTION
# Description

This  resolves unneeded subsequent restarts of `phpX.Y-fpm` service upon FPM pool configuration update. 
If more than 5 FPM pools are affected of a configuration change, `systemd` will fail to restart the service with following error:
```
php8.1-fpm.service: Start request repeated too quickly.
php8.1-fpm.service: Failed with result 'start-limit-hit'.
Failed to start The PHP 8.1 FastCGI Process Manager.
```
Although according to [chef resource](https://docs.chef.io/resource_common/#timers) documentation the `default` value for the `:timer` is `:delayed`, it seems not to be the case and should be explicitly set.
This behavior may be observed at the github's [regressions tests](https://github.com/sous-chefs/php/actions/runs/11060632644/job/30731606949#step:4:1974)


## Issues Resolved

* [160](https://github.com/sous-chefs/php/issues/160)

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
