### PR TITLE
docs: describe caveat and workaround for multiple fpm pools

### DIFF
--- a/documentation/php_fpm_pool.md
+++ b/documentation/php_fpm_pool.md
@@ -28,7 +28,6 @@ More info: <https://www.php.net/manual/en/install.fpm.php>
 | `additional_config` | `Hash`          | `{}`                                 | Additional parameters in JSON                                                         |
 | `fpm_ini_control`   | `[true, false]` | `false`                              | Whether to add a new `php.ini` file for FPM                                           |
 
-
 ## Examples
 
 1. Install a FPM pool named 'default'
@@ -44,7 +43,7 @@ More info: <https://www.php.net/manual/en/install.fpm.php>
    If more than `5` FPM pools are affected by a configuration change, this will lead to subsequent `5+` service restarts.
    However, `systemd` will deny this number of subsequent service restarts with the following error:
 
-   ```
+   ```bash
    php8.1-fpm.service: Start request repeated too quickly.
    php8.1-fpm.service: Failed with result 'start-limit-hit'.
    Failed to start The PHP 8.1 FastCGI Process Manager.
@@ -52,7 +51,7 @@ More info: <https://www.php.net/manual/en/install.fpm.php>
 
    This behavior is due to the `unified_mode true` setting of an `fpm_pool` custom resource, which is a [default setting](https://docs.chef.io/deprecations_unified_mode/) for `chef-clients v18+`. In this mode, notifications set as `:delayed` within a custom resource action (like `action :install`) are queued to be processed once the action completes (i.e., at the end of the resource `action :install` block), rather than waiting until the end of the Chef client run.
 
-   ### Possible Workaround
+   **Possible Workaround**
 
    In a wrapper cookbook, define a `ruby_block` with a call to the `sleep(X)` function, which will be called upon an `fpm_pool` resource update:
 


### PR DESCRIPTION
# Description

Added documentation on handling multiple php-fpm service restarts when provisioning multiple FPM pools. This serves as an addendum to [PR 365](https://github.com/sous-chefs/php/pull/365) and a RFC at once. 

While the change in  [PR 365](https://github.com/sous-chefs/php/pull/365) was not entirely incorrect *(default `:delayed` notification `:timer` was explicitly set)*, it did not address the issue at all.

After investigating the problem further and testing a working solution, I’d like to share my findings.

Since `chef-client v18`,[unified_mode true](https://docs.chef.io/deprecations_unified_mode/) is the default setting for custom resources. 

With `unified_mode true` enabled:
* Single-phase Execution: Properties and actions are unified, meaning that everything inside the resource *(properties, actions, notifications)* is evaluated in one continuous phase.
* End-of-Action Notifications: Notifications set as `:delayed` within a custom resource action _(like `action :install`)_ are queued to be processed _once the action completes_, rather than waiting until the end of the Chef client run.

This means that my previous assertion in [PR 365](https://github.com/sous-chefs/php/pull/365) was incorrect. Although the service resource notification was indeed set to `:delayed`, due to `unified_mode true` it was triggered at the end of the `action :install` block within the `fpm_pool` resource, not at the end of the `chef-client` run.

Documentation has been added; feedback is welcome.

## Issues Resolved

Caveat and possible Workaround for managing multiple FPM pools documented.

## Check List

- [-] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [-] New functionality includes testing.
- [-] New functionality has been documented in the README if applicable.
